### PR TITLE
add another convertLongitude (WIP)

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/util/NetcdfUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/NetcdfUtil.java
@@ -38,6 +38,25 @@ public class NetcdfUtil {
         return NetcdfFiles.open(file.getAbsolutePath());
     }
 
+    public static double parseDmsToDecimal(String dms) {
+        // Converts Degrees-Minutes-Seconds coordinates to Decimal degrees
+        String[] parts = dms.split("[°'']");
+
+        // Extract the degrees, minutes, and seconds values
+        double degrees = Double.parseDouble(parts[0]);
+        double minutes = Double.parseDouble(parts[1]);
+        double seconds = Double.parseDouble(parts[2]);
+
+        // Calculate decimal degrees
+        double decimalDegrees = degrees + (minutes / 60) + (seconds / 3600);
+
+        // Check the direction (E, W, N, or S) and adjust the sign accordingly
+        if (dms.contains("W") || dms.contains("S")) {
+            decimalDegrees = -decimalDegrees;
+        }
+        return decimalDegrees;
+    }
+
     public static double convertLongitude(double lon) {
         // Converts a longitude from the range of 0-360 to -180-180
         lon = (lon + 180) % 360 - 180;

--- a/src/main/java/edu/harvard/iq/dataverse/util/NetcdfUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/NetcdfUtil.java
@@ -16,6 +16,7 @@ public class NetcdfUtil {
     public static final String EAST_LONGITUDE_KEY = "geospatial_lon_max";
     public static final String NORTH_LATITUDE_KEY = "geospatial_lat_max";
     public static final String SOUTH_LATITUDE_KEY = "geospatial_lat_min";
+    public static final String LONGITUDE_UNITS = "geospatial_lon_units";
 
     public static NetcdfFile getNetcdfFile(File file) throws IOException {
         /**
@@ -73,8 +74,10 @@ public class NetcdfUtil {
         Attribute eastLongitude = netcdfFile.findGlobalAttribute(EAST_LONGITUDE_KEY);
         Attribute northLatitude = netcdfFile.findGlobalAttribute(NORTH_LATITUDE_KEY);
         Attribute southLatitude = netcdfFile.findGlobalAttribute(SOUTH_LATITUDE_KEY);
+        Attribute unitLongitude = netcdfFile.findGlobalAttribute(LONGITUDE_UNITS);
 
-        if (getValue(eastLongitude) > 180 || getValue(westLongitude) > 180) {
+        if (getValue(unitLongitude).matches("(?i)(degree(s)?|decimal_degrees)[\s_-]?(e(ast)?)")) {
+            // According to CT convention "degree(s)_e(ast)" is typically in range 0-360
             double revisedEastLongitude = convertLongitude(getValue(eastLongitude));
             double revisedWestLongitude = convertLongitude(getValue(westLongitude));
         }

--- a/src/main/java/edu/harvard/iq/dataverse/util/NetcdfUtil.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/NetcdfUtil.java
@@ -38,6 +38,12 @@ public class NetcdfUtil {
         return NetcdfFiles.open(file.getAbsolutePath());
     }
 
+    public static double convertLongitude(double lon) {
+        // Converts a longitude from the range of 0-360 to -180-180
+        lon = (lon + 180) % 360 - 180;
+        return lon;
+    }
+
     public static Map<String, String> parseGeospatial(NetcdfFile netcdfFile) {
         Map<String, String> geoFields = new HashMap<>();
 
@@ -49,8 +55,17 @@ public class NetcdfUtil {
         Attribute northLatitude = netcdfFile.findGlobalAttribute(NORTH_LATITUDE_KEY);
         Attribute southLatitude = netcdfFile.findGlobalAttribute(SOUTH_LATITUDE_KEY);
 
-        geoFields.put(DatasetFieldConstant.westLongitude, getValue(westLongitude));
-        geoFields.put(DatasetFieldConstant.eastLongitude, getValue(eastLongitude));
+        if (getValue(eastLongitude) > 180 || getValue(westLongitude) > 180) {
+            double revisedEastLongitude = convertLongitude(getValue(eastLongitude));
+            double revisedWestLongitude = convertLongitude(getValue(westLongitude));
+        }
+        else {
+            double revisedEastLongitude = getValue(eastLongitude);
+            double revisedWestLongitude = getValue(westLongitude);
+        }
+
+        geoFields.put(DatasetFieldConstant.westLongitude, revisedWestLongitude);
+        geoFields.put(DatasetFieldConstant.eastLongitude, revisedEastLongitude);
         geoFields.put(DatasetFieldConstant.northLatitude, getValue(northLatitude));
         geoFields.put(DatasetFieldConstant.southLatitude, getValue(southLatitude));
 


### PR DESCRIPTION
This pull request implements a `convertLongitude` method that assumes:

- If `lon_units` is `degree east` then the degree range is 0-360
- if it is `degree west` then the range is -180-180

See also:
- CF convention for longitude (`degree east` and variations): https://cfconventions.org/cf-conventions/v1.6.0/cf-conventions.html#longitude-coordinate
- See discussion at: https://github.com/cf-convention/cf-conventions/issues/435

----

The `parseDmsToDecimal` method is another helper method for parsing and converting values from `boundingbox` in the format 37°25'19.07"N, 122°05'06.24"W to degrees.

See example dataset: https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/1HTKPJ > Geospatial metadata